### PR TITLE
Box collision parsing

### DIFF
--- a/lib.flist
+++ b/lib.flist
@@ -27,6 +27,7 @@ lib/physics/level_geometry.o
 lib/physics/objects/bouncy_object.o
 lib/physics/objects/character_body.o
 lib/physics/collider.o
+lib/physics/importers/importers.o
 
 lib/graphics/primitives/matrix_stack.o
 lib/graphics/primitives/shader.o

--- a/lib/graphics/primitives/mesh.cpp
+++ b/lib/graphics/primitives/mesh.cpp
@@ -5,6 +5,7 @@
 #include <stdio.h>
 
 #include <assimp/Importer.hpp>
+#include <string>
 
 #include "graphics/gl_debug.h"
 #include "logger/logger.h"
@@ -18,9 +19,9 @@ void Mesh::load(const char* path) {
 
     log_printf(STATUS_REPORTS, "status", "Loading model %s\n", path);
 
-    const aiScene* scene =
-        import.ReadFile(path, aiProcess_Triangulate | aiProcess_FlipUVs |
-                                  aiProcess_CalcTangentSpace);
+    const aiScene* scene = import.ReadFile(
+        path, aiProcess_Triangulate | aiProcess_FlipUVs |
+                  aiProcess_CalcTangentSpace | aiProcess_JoinIdenticalVertices);
 
     if (!scene || scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE ||
         !scene->mRootNode) {
@@ -34,6 +35,10 @@ void Mesh::load(const char* path) {
 
     for (size_t mesh_id = 0; mesh_id < scene->mNumMeshes; ++mesh_id) {
         aiMesh* mesh = meshes[mesh_id];
+
+        //* `_box_` objects define collision boxes and should not be imported
+        if (strncmp(mesh->mName.C_Str(), "_box_", 5) == 0) continue;
+
         size_t vertex_count = mesh->mNumVertices;
 
         unsigned uv_depth = mesh->GetNumUVChannels();

--- a/lib/physics/collider.cpp
+++ b/lib/physics/collider.cpp
@@ -139,6 +139,15 @@ Intersection SphereCollider::intersect_box(const BoxCollider& box) const {
         closest = intersection;
     }
 
+    glm::mat4 local_to_world = box.get_transform();
+    glm::vec4 new_center = local_to_world * glm::vec4(closest.center, 1.0);
+    glm::vec4 new_delta = local_to_world * glm::vec4(closest.delta, 0.0);
+
+    new_center /= new_center.w;
+
+    closest.center = glm::vec3(new_center.x, new_center.y, new_center.z);
+    closest.delta = glm::vec3(new_delta.x, new_delta.y, new_delta.z);
+
     return closest;
 }
 

--- a/lib/physics/importers/importers.cpp
+++ b/lib/physics/importers/importers.cpp
@@ -1,0 +1,130 @@
+#include <assimp/postprocess.h>
+#include <assimp/scene.h>
+#include <tinyxml2.h>
+
+#include <assimp/Importer.hpp>
+#include <optional>
+#include <utility>
+
+#include "logger/logger.h"
+#include "managers/asset_manager.h"
+#include "physics/level_geometry.h"
+
+static std::optional<BoxCollider> parse_box(
+    const std::vector<glm::vec3>& vertices) {
+    if (vertices.size() < 8) {
+        log_printf(WARNINGS, "warning", "Not enough vertices\n");
+        return {};
+    }
+
+    glm::vec3 origin = vertices[0];
+
+    glm::vec3 arm_x = glm::vec3(0.0, 0.0, 0.0);
+    glm::vec3 arm_y = glm::vec3(0.0, 0.0, 0.0);
+
+    for (glm::vec3 vertex : vertices) {
+        glm::vec3 arm = vertex - origin;
+
+        if (glm::length(arm) < 1e-4) continue;
+
+        if (glm::length(arm) < glm::length(arm_x) ||
+            glm::length(arm_x) < 1e-4) {
+            arm_y = arm_x;
+            arm_x = arm;
+        } else if (glm::length(arm) < glm::length(arm_y) ||
+                   glm::length(arm_y) < 1e-4) {
+            arm_y = arm;
+        }
+    }
+
+    glm::vec3 arm_z = glm::vec3(0.0, 0.0, 0.0);
+
+    glm::vec3 normal = glm::cross(arm_x, arm_y);
+    if (glm::length(normal) < 1e-4) {
+        log_printf(WARNINGS, "warning",
+                   "Base vectors produce zero determinant\n");
+        return {};
+    }
+
+    normal = glm::normalize(normal);
+
+    for (glm::vec3 vertex : vertices) {
+        glm::vec3 arm = normal * glm::dot(normal, vertex - origin);
+
+        if (glm::length(arm) > glm::length(arm_z)) {
+            arm_z = arm;
+        }
+    }
+
+    if (glm::dot(glm::cross(arm_x, arm_y), arm_z) > 0.0) {
+        std::swap(arm_x, arm_y);
+    }
+
+    glm::vec3 size(glm::length(arm_x), glm::length(arm_y), glm::length(arm_z));
+
+    Box box(size / 2.0f, size);
+
+    glm::vec4 x_axis(glm::normalize(arm_x), 0.0f);
+    glm::vec4 y_axis(glm::normalize(arm_y), 0.0f);
+    glm::vec4 z_axis(glm::normalize(arm_z), 0.0f);
+    glm::vec4 w_axis(origin, 1.0f);
+
+    glm::mat4 transform = glm::mat4(x_axis, y_axis, z_axis, w_axis);
+
+    return BoxCollider(box, transform);
+}
+
+IMPORTER(CollisionGroup, "obj") {
+    static Assimp::Importer import;
+
+    CollisionGroup group = {};
+
+    const aiScene* scene =
+        import.ReadFile(path, aiProcess_JoinIdenticalVertices);
+
+    if (!scene || scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE ||
+        !scene->mRootNode) {
+        log_printf(ERROR_REPORTS, "error", "Failed to load collision for %s\n",
+                   path);
+        return nullptr;
+    }
+
+    aiMesh** meshes = scene->mMeshes;
+
+    for (size_t mesh_id = 0; mesh_id < scene->mNumMeshes; ++mesh_id) {
+        aiMesh* mesh = meshes[mesh_id];
+
+        if (strncmp(mesh->mName.C_Str(), "_box_", 5) != 0) continue;
+
+        size_t vertex_count = mesh->mNumVertices;
+
+        std::vector<glm::vec3> vertices;
+
+        for (size_t vrt_id = 0; vrt_id < vertex_count; ++vrt_id) {
+            aiVector3D pos = mesh->mVertices[vrt_id];
+
+            glm::vec3 new_vertex = glm::vec3(pos.x, pos.y, pos.z);
+
+            bool duplicate = false;
+            for (const glm::vec3& vertex : vertices) {
+                if (glm::distance(vertex, new_vertex) < 1e-4) duplicate = true;
+            }
+
+            if (duplicate) continue;
+
+            vertices.push_back(new_vertex);
+        }
+
+        std::optional<BoxCollider> collider = parse_box(vertices);
+
+        if (collider.has_value()) {
+            group.push_back(collider.value());
+        } else {
+            log_printf(WARNINGS, "warning",
+                       "Collision box \"%s\" (file %s) is invalid\n",
+                       mesh->mName.C_Str(), path);
+        }
+    }
+
+    return new Asset<CollisionGroup>(group);
+}


### PR DESCRIPTION
It is now possible to import model collisions directly from their corresponding `.obj` files.

## How to use

```C++
CollisionGroup colliders =
    *AssetManager::request<CollisionGroup>("path/to/the/model.obj");

// CollisionGroup is just a `std::vector<BoxCollider>`
for (const BoxCollider& collider : colliders) {
    // Register imported colliders

    . . .
}
```

## Asset format
Colliders can be defined directly inside model files.
To add a collider to a model, create a box mesh inside the modelling software of your choice, position it using rotation and scaling tools in local space (box edges must remain perpendicular to each other), and name it with the `_box_` prefix (f.e. `_box_TreeTrunk`).

The framework will detect all objects named with the specified prefix and try to reconstruct box colliders from their geometry.
The framework will print out a warning if it fails to reconstruct a collider by its defining object. No additional checks will be performed to ensure the given primitives are correct and match the result of the approximation.