### PR TITLE
Import failure messages

### DIFF
--- a/lib/graphics/importers/importers.cpp
+++ b/lib/graphics/importers/importers.cpp
@@ -20,8 +20,16 @@ IMPORTER(Texture, "texture") {
         return nullptr;
     }
 
-    if (element->FirstChildElement("path") == nullptr) return nullptr;
-    if (element->FirstChildElement("slot") == nullptr) return nullptr;
+    if (element->FirstChildElement("path") == nullptr) {
+        log_printf(ERROR_REPORTS, "error",
+                   "Unspecified texture path (`path` tag)\n");
+        return nullptr;
+    }
+    if (element->FirstChildElement("slot") == nullptr) {
+        log_printf(ERROR_REPORTS, "error",
+                   "Unspecified texture slot (`slot` tag)\n");
+        return nullptr;
+    }
 
     unsigned slot = 0;
 
@@ -44,8 +52,16 @@ IMPORTER(Shader, "shader") {
         return nullptr;
     }
 
-    if (element->FirstChildElement("vsh") == nullptr) return nullptr;
-    if (element->FirstChildElement("fsh") == nullptr) return nullptr;
+    if (element->FirstChildElement("vsh") == nullptr) {
+        log_printf(ERROR_REPORTS, "error",
+                   "Unspecified vertex shader path (`vsh` tag)\n");
+        return nullptr;
+    }
+    if (element->FirstChildElement("fsh") == nullptr) {
+        log_printf(ERROR_REPORTS, "error",
+                   "Unspecified fragment shader path (`fsh` tag)\n");
+        return nullptr;
+    }
 
     static char vsh_name[PATH_LENGTH] = "";
     static char fsh_name[PATH_LENGTH] = "";

--- a/lib/input/keybind_importer.cpp
+++ b/lib/input/keybind_importer.cpp
@@ -11,7 +11,11 @@ IMPORTER(BinaryInput, "keybind") {
 
     const tinyxml2::XMLElement* element = doc.FirstChildElement("keybind");
 
-    if (element == nullptr) return nullptr;
+    if (element == nullptr) {
+        log_printf(ERROR_REPORTS, "error",
+                   "Invalid keybind descriptor header\n");
+        return nullptr;
+    }
 
     Asset<BinaryInput>* asset = new Asset<BinaryInput>();
 
@@ -22,17 +26,14 @@ IMPORTER(BinaryInput, "keybind") {
 
         if (code == nullptr) {
             log_printf(WARNINGS, "warning",
-                       "Input action code was not specified. This input will "
-                       "be ignored.\n");
+                       "Input action code was not specified\n");
         }
 
         const InputAction* action = InputController::get_action(code);
 
         if (action == nullptr) {
             log_printf(WARNINGS, "warning",
-                       "Input action \"%s\" does not exist, this input will be "
-                       "ignored.\n",
-                       code);
+                       "Input action \"%s\" does not exist\n", code);
         }
 
         asset->content.add_activator(*action);

--- a/lib/managers/_am_request.hpp
+++ b/lib/managers/_am_request.hpp
@@ -9,12 +9,8 @@ const T* AssetManager::request(const char* path) {
         return &((Asset<T>*)asset->second)->content;
     }
 
-    log_printf(STATUS_REPORTS, "status",
-               "Loading asset \"%s\" (type %0lX) (identifier hash %0lX, "
-               "storage size %lu)\n",
-               identifier.path, identifier.type_id,
-               std::hash<AssetManager::AssetRequest>{}(identifier),
-               assets_.size());
+    log_printf(STATUS_REPORTS, "status", "Loading asset \"%s\" (type %0lX)\n",
+               identifier.path, identifier.type_id);
 
     static char signature[128] = "";
 
@@ -38,10 +34,10 @@ const T* AssetManager::request(const char* path) {
     ImporterId importer_id(typeid(T).hash_code(), signature);
     auto importer_cell = importers_.find(importer_id);
     if (importer_cell == importers_.end()) {
-        log_printf(
-            ERROR_REPORTS, "error",
-            "Failed to find importer matching signature %s (type %0lX)\n",
-            signature, importer_id.type_id);
+        log_printf(ERROR_REPORTS, "error",
+                   "Failed to find importer matching the signature \"%s\" "
+                   "(type %0lX)\n",
+                   signature, importer_id.type_id);
         return nullptr;
     }
 
@@ -49,7 +45,7 @@ const T* AssetManager::request(const char* path) {
 
     if (imported == nullptr) {
         log_printf(ERROR_REPORTS, "error",
-                   "Failed to import asset %s (type %0lX)\n", path,
+                   "Failed to import the asset \"%s\" (type %0lX)\n", path,
                    identifier.type_id);
         return nullptr;
     }


### PR DESCRIPTION
More fail cases now produce error messages.

Also, material importer now considers invalid textures as minor failures and does not invalidate an entire material.
Failure to import a texture uniform now produces a warning instead of an error and does not terminate the material definition.