### PR TITLE
Texture import without explicit slot specification

### DIFF
--- a/assets/materials/field.material.xml
+++ b/assets/materials/field.material.xml
@@ -1,6 +1,6 @@
 <material>
     <shader path="assets/shaders/basic.shader.xml"></shader>
 
-    <texture uniform="albedo" path="assets/textures/green_field.texture.xml"></texture>
+    <texture uniform="albedo" path="assets/textures/green_field.png"></texture>
     <texture uniform="ao_map" path="assets/textures/field_ao.texture.xml"></texture>
 </material>

--- a/assets/materials/frame.material.xml
+++ b/assets/materials/frame.material.xml
@@ -1,7 +1,7 @@
 <material>
     <shader path="assets/shaders/basic.shader.xml"></shader>
 
-    <texture uniform="albedo" path="assets/textures/wood.texture.xml"></texture>
+    <texture uniform="albedo" path="assets/textures/wood.png"></texture>
 
     <texture uniform="ao_map" path="assets/textures/frame_ao.texture.xml"></texture>
 </material>

--- a/assets/materials/red_ball.material.xml
+++ b/assets/materials/red_ball.material.xml
@@ -1,5 +1,5 @@
 <material>
     <shader path="assets/shaders/albedo_only.shader.xml"></shader>
 
-    <texture var="albedo" path="assets/textures/noisy_red.texture.xml"></texture>
+    <texture var="albedo" path="assets/textures/noisy_red.png"></texture>
 </material>

--- a/assets/materials/rock.material.xml
+++ b/assets/materials/rock.material.xml
@@ -1,7 +1,7 @@
 <material>
     <shader path="assets/shaders/basic.shader.xml"></shader>
 
-    <texture uniform="albedo" path="assets/textures/rock.texture.xml"></texture>
+    <texture uniform="albedo" path="assets/textures/rock.png"></texture>
 
     <texture uniform="ao_map" path="assets/textures/monkey_ao.texture.xml"></texture>
 </material>

--- a/assets/materials/white_ball.material.xml
+++ b/assets/materials/white_ball.material.xml
@@ -1,5 +1,5 @@
 <material>
     <shader path="assets/shaders/albedo_only.shader.xml"></shader>
 
-    <texture uniform="albedo" path="assets/textures/noisy_white.texture.xml"></texture>
+    <texture uniform="albedo" path="assets/textures/noisy_white.png"></texture>
 </material>

--- a/assets/models/arrow.model.xml
+++ b/assets/models/arrow.model.xml
@@ -1,4 +1,4 @@
 <model>
-    <mesh>assets/models/arrow.obj</mesh>
-    <material>assets/materials/white_ball.material.xml</material>
+    <mesh path="assets/models/arrow.obj"></mesh>
+    <material path="assets/materials/white_ball.material.xml"></material>
 </model>

--- a/assets/models/field.model.xml
+++ b/assets/models/field.model.xml
@@ -1,4 +1,4 @@
 <model>
-    <mesh>assets/models/field.obj</mesh>
-    <material>assets/materials/field.material.xml</material>
+    <mesh path="assets/models/field.obj"></mesh>
+    <material path="assets/materials/field.material.xml"></material>
 </model>

--- a/assets/models/frame.model.xml
+++ b/assets/models/frame.model.xml
@@ -1,4 +1,4 @@
 <model>
-    <mesh>assets/models/frame.obj</mesh>
-    <material>assets/materials/frame.material.xml</material>
+    <mesh path="assets/models/frame.obj"></mesh>
+    <material path="assets/materials/frame.material.xml"></material>
 </model>

--- a/assets/models/main_ball.model.xml
+++ b/assets/models/main_ball.model.xml
@@ -1,4 +1,4 @@
 <model>
-    <mesh>assets/models/pool_ball.obj</mesh>
-    <material>assets/materials/white_ball.material.xml</material>
+    <mesh path="assets/models/pool_ball.obj"></mesh>
+    <material path="assets/materials/white_ball.material.xml"></material>
 </model>

--- a/assets/models/monkey.model.xml
+++ b/assets/models/monkey.model.xml
@@ -1,4 +1,4 @@
 <model>
-    <mesh>assets/models/monkey.obj</mesh>
-    <material>assets/materials/rock.material.xml</material>
+    <mesh path="assets/models/monkey.obj"></mesh>
+    <material path="assets/materials/rock.material.xml"></material>
 </model>

--- a/assets/models/red_ball.model.xml
+++ b/assets/models/red_ball.model.xml
@@ -1,4 +1,4 @@
 <model>
-    <mesh>assets/models/pool_ball.obj</mesh>
-    <material>assets/materials/red_ball.material.xml</material>
+    <mesh path="assets/models/pool_ball.obj"></mesh>
+    <material path="assets/materials/red_ball.material.xml"></material>
 </model>

--- a/assets/shaders/RB2SCR.shader.xml
+++ b/assets/shaders/RB2SCR.shader.xml
@@ -1,4 +1,4 @@
 <shader>
-    <fsh>assets/shaders/identity.fsh</fsh>
-    <vsh>assets/shaders/identity.vsh</vsh>
+    <fsh path="assets/shaders/identity.fsh"></fsh>
+    <vsh path="assets/shaders/identity.vsh"></vsh>
 </shader>

--- a/assets/shaders/albedo_only.shader.xml
+++ b/assets/shaders/albedo_only.shader.xml
@@ -1,4 +1,4 @@
 <shader>
-    <fsh>assets/shaders/albedo_only.fsh</fsh>
-    <vsh>assets/shaders/basic.vsh</vsh>
+    <fsh path="assets/shaders/albedo_only.fsh"></fsh>
+    <vsh path="assets/shaders/basic.vsh"></vsh>
 </shader>

--- a/assets/shaders/basic.shader.xml
+++ b/assets/shaders/basic.shader.xml
@@ -1,4 +1,4 @@
 <shader>
-    <fsh>assets/shaders/basic.fsh</fsh>
-    <vsh>assets/shaders/basic.vsh</vsh>
+    <fsh path="assets/shaders/basic.fsh"></fsh>
+    <vsh path="assets/shaders/basic.vsh"></vsh>
 </shader>

--- a/assets/shaders/decals/red_paint.shader.xml
+++ b/assets/shaders/decals/red_paint.shader.xml
@@ -1,4 +1,4 @@
 <shader>
-    <fsh>assets/shaders/decals/red_paint.fsh</fsh>
-    <vsh>assets/shaders/identity.vsh</vsh>
+    <fsh path="assets/shaders/decals/red_paint.fsh"></fsh>
+    <vsh path="assets/shaders/identity.vsh</">vsh>
 </shader>

--- a/assets/shaders/lights/ambient_light.shader.xml
+++ b/assets/shaders/lights/ambient_light.shader.xml
@@ -1,4 +1,4 @@
 <shader>
-    <fsh>assets/shaders/lights/ambient_light.fsh</fsh>
-    <vsh>assets/shaders/identity.vsh</vsh>
+    <fsh path="assets/shaders/lights/ambient_light.fsh"></fsh>
+    <vsh path="assets/shaders/identity.vsh"></vsh>
 </shader>

--- a/assets/shaders/lights/point_light.shader.xml
+++ b/assets/shaders/lights/point_light.shader.xml
@@ -1,4 +1,4 @@
 <shader>
-    <fsh>assets/shaders/lights/point_light.fsh</fsh>
-    <vsh>assets/shaders/identity.vsh</vsh>
+    <fsh path="assets/shaders/lights/point_light.fsh"></fsh>
+    <vsh path="assets/shaders/identity.vsh"></vsh>
 </shader>

--- a/assets/shaders/postprocessing/contrast_vignette.shader.xml
+++ b/assets/shaders/postprocessing/contrast_vignette.shader.xml
@@ -1,4 +1,4 @@
 <shader>
-    <fsh>assets/shaders/postprocessing/contrast_vignette.fsh</fsh>
-    <vsh>assets/shaders/identity.vsh</vsh>
+    <fsh path="assets/shaders/postprocessing/contrast_vignette.fsh"></fsh>
+    <vsh path="assets/shaders/identity.vsh"></vsh>
 </shader>

--- a/assets/shaders/rough_albedo.shader.xml
+++ b/assets/shaders/rough_albedo.shader.xml
@@ -1,4 +1,4 @@
 <shader>
-    <fsh>assets/shaders/rough_albedo.fsh</fsh>
-    <vsh>assets/shaders/basic.vsh</vsh>
+    <fsh path="assets/shaders/rough_albedo.fsh"></fsh>
+    <vsh path="assets/shaders/basic.vsh"></vsh>
 </shader>

--- a/assets/textures/ball_ao.texture.xml
+++ b/assets/textures/ball_ao.texture.xml
@@ -1,5 +1,5 @@
 <texture>
     <file path="assets/textures/ball_ao.png"></file>
     <interp mode="linear"></interp>
-    <wrap mode="clamp_to_edge" r="1.0" g="1.0" b="1.0"></wrap>
+    <wrap mode="clamp_to_border" r="1.0" g="1.0" b="1.0"></wrap>
 </texture>

--- a/assets/textures/ball_ao.texture.xml
+++ b/assets/textures/ball_ao.texture.xml
@@ -1,4 +1,5 @@
 <texture>
-    <path>assets/textures/ball_ao.png</path>
-    <slot>1</slot>
+    <file path="assets/textures/ball_ao.png"></file>
+    <interp mode="linear"></interp>
+    <wrap mode="clamp_to_edge" r="1.0" g="1.0" b="1.0"></wrap>
 </texture>

--- a/assets/textures/field_ao.texture.xml
+++ b/assets/textures/field_ao.texture.xml
@@ -1,5 +1,5 @@
 <texture>
     <file path="assets/textures/field_ao.png"></file>
     <interp mode="linear"></interp>
-    <wrap mode="clamp_to_edge" r="1.0" g="1.0" b="1.0"></wrap>
+    <wrap mode="clamp_to_border" r="1.0" g="1.0" b="1.0"></wrap>
 </texture>

--- a/assets/textures/field_ao.texture.xml
+++ b/assets/textures/field_ao.texture.xml
@@ -1,4 +1,5 @@
 <texture>
-    <path>assets/textures/field_ao.png</path>
-    <slot>1</slot>
+    <file path="assets/textures/field_ao.png"></file>
+    <interp mode="linear"></interp>
+    <wrap mode="clamp_to_edge" r="1.0" g="1.0" b="1.0"></wrap>
 </texture>

--- a/assets/textures/frame_ao.texture.xml
+++ b/assets/textures/frame_ao.texture.xml
@@ -1,5 +1,5 @@
 <texture>
     <file path="assets/textures/frame_ao.png"></file>
     <interp mode="linear"></interp>
-    <wrap mode="clamp_to_edge" r="1.0" g="1.0" b="1.0"></wrap>
+    <wrap mode="clamp_to_border" r="1.0" g="1.0" b="1.0"></wrap>
 </texture>

--- a/assets/textures/frame_ao.texture.xml
+++ b/assets/textures/frame_ao.texture.xml
@@ -1,4 +1,5 @@
 <texture>
-    <path>assets/textures/frame_ao.png</path>
-    <slot>1</slot>
+    <file path="assets/textures/frame_ao.png"></file>
+    <interp mode="linear"></interp>
+    <wrap mode="clamp_to_edge" r="1.0" g="1.0" b="1.0"></wrap>
 </texture>

--- a/assets/textures/green_field.texture.xml
+++ b/assets/textures/green_field.texture.xml
@@ -1,4 +1,0 @@
-<texture>
-    <path>assets/textures/green_field.png</path>
-    <slot>0</slot>
-</texture>

--- a/assets/textures/monkey_ao.texture.xml
+++ b/assets/textures/monkey_ao.texture.xml
@@ -1,5 +1,5 @@
 <texture>
     <file path="assets/textures/monkey_ao.png"></file>
     <interp mode="linear"></interp>
-    <wrap mode="clamp_to_edge" r="1.0" g="1.0" b="1.0"></wrap>
+    <wrap mode="clamp_to_border" r="1.0" g="1.0" b="1.0"></wrap>
 </texture>

--- a/assets/textures/monkey_ao.texture.xml
+++ b/assets/textures/monkey_ao.texture.xml
@@ -1,4 +1,5 @@
 <texture>
-    <path>assets/textures/monkey_ao.png</path>
-    <slot>1</slot>
+    <file path="assets/textures/monkey_ao.png"></file>
+    <interp mode="linear"></interp>
+    <wrap mode="clamp_to_edge" r="1.0" g="1.0" b="1.0"></wrap>
 </texture>

--- a/assets/textures/noise.texture.xml
+++ b/assets/textures/noise.texture.xml
@@ -1,4 +1,5 @@
 <texture>
-    <path>assets/textures/noise.png</path>
-    <slot>2</slot>
+    <file path="assets/textures/noise.png"></file>
+    <interp mode="linear"></interp>
+    <wrap mode="mirrored_repeat"></wrap>
 </texture>

--- a/assets/textures/noisy_red.texture.xml
+++ b/assets/textures/noisy_red.texture.xml
@@ -1,4 +1,0 @@
-<texture>
-    <path>assets/textures/noisy_red.png</path>
-    <slot>0</slot>
-</texture>

--- a/assets/textures/noisy_white.texture.xml
+++ b/assets/textures/noisy_white.texture.xml
@@ -1,4 +1,0 @@
-<texture>
-    <path>assets/textures/noisy_white.png</path>
-    <slot>0</slot>
-</texture>

--- a/assets/textures/rock.texture.xml
+++ b/assets/textures/rock.texture.xml
@@ -1,4 +1,0 @@
-<texture>
-    <path>assets/textures/rock.jpg</path>
-    <slot>0</slot>
-</texture>

--- a/assets/textures/wood.texture.xml
+++ b/assets/textures/wood.texture.xml
@@ -1,4 +1,0 @@
-<texture>
-    <path>assets/textures/wood.png</path>
-    <slot>0</slot>
-</texture>

--- a/assets/textures/wood_rghs.texture.xml
+++ b/assets/textures/wood_rghs.texture.xml
@@ -1,4 +1,0 @@
-<texture>
-    <path>assets/textures/wood_rghs.png</path>
-    <slot>2</slot>
-</texture>

--- a/lib/graphics/importers/importers.cpp
+++ b/lib/graphics/importers/importers.cpp
@@ -37,7 +37,7 @@ IMPORTER(Texture, "texture") {
         trim_path(element->FirstChildElement("path")->GetText());
     element->FirstChildElement("slot")->QueryUnsignedText(&slot);
 
-    return new Asset<Texture>(content_path, slot);
+    return new Asset<Texture>(content_path);
 }
 
 IMPORTER(Shader, "shader") {

--- a/lib/graphics/importers/importers.cpp
+++ b/lib/graphics/importers/importers.cpp
@@ -29,15 +29,15 @@ void read_wrap(const tinyxml2::XMLElement* element, TextureSettings& settings) {
         settings.wrap = GL_REPEAT;
     } else if (strcmp(name, "mirrored_repeat") == 0) {
         settings.wrap = GL_MIRRORED_REPEAT;
-    } else if (strcmp(name, "clamp_to_border") == 0) {
-        settings.wrap = GL_CLAMP_TO_BORDER;
     } else if (strcmp(name, "clamp_to_edge") == 0) {
         settings.wrap = GL_CLAMP_TO_EDGE;
+    } else if (strcmp(name, "clamp_to_border") == 0) {
+        settings.wrap = GL_CLAMP_TO_BORDER;
 
-        // CLAMP_TO_EDGE fills unmapped pixels of the image with BORDER_COLOR
+        // CLAMP_TO_BORDER fills unmapped pixels of the image with BORDER_COLOR
         // This is where the user can define the color they want to use
 
-        // <wrap mode="clamp_to_edge" r="1.0" g="0.0" b="1.0"></wrap>
+        // <wrap mode="clamp_to_border" r="1.0" g="0.0" b="1.0"></wrap>
         //                            ^^^^^^^^^^^^^^^^^^^^^^^
 
         element->QueryFloatAttribute("r", &settings.color.r);

--- a/lib/graphics/importers/importers.cpp
+++ b/lib/graphics/importers/importers.cpp
@@ -33,39 +33,39 @@ void read_wrap(const tinyxml2::XMLElement* element, TextureSettings& settings) {
         settings.wrap = GL_CLAMP_TO_EDGE;
     } else if (strcmp(name, "clamp_to_border") == 0) {
         settings.wrap = GL_CLAMP_TO_BORDER;
-
-        // CLAMP_TO_BORDER fills unmapped pixels of the image with BORDER_COLOR
-        // This is where the user can define the color they want to use
-
-        // <wrap mode="clamp_to_border" r="1.0" g="0.0" b="1.0"></wrap>
-        //                            ^^^^^^^^^^^^^^^^^^^^^^^
-
-        element->QueryFloatAttribute("r", &settings.color.r);
-        element->QueryFloatAttribute("g", &settings.color.g);
-        element->QueryFloatAttribute("b", &settings.color.b);
-
-        element->QueryFloatAttribute("red", &settings.color.r);
-        element->QueryFloatAttribute("green", &settings.color.g);
-        element->QueryFloatAttribute("blue", &settings.color.b);
-
-        float red = settings.color.r;
-        float green = settings.color.g;
-        float blue = settings.color.b;
-
-        if (red < 0.0 || red > 1.0 || green < 0.0 || green > 1.0 ||
-            blue < 0.0 || blue > 1.0) {
-            settings.color.r = glm::clamp(settings.color.r, 0.0f, 1.0f);
-            settings.color.g = glm::clamp(settings.color.g, 0.0f, 1.0f);
-            settings.color.b = glm::clamp(settings.color.b, 0.0f, 1.0f);
-
-            log_printf(WARNINGS, "warning",
-                       "Clamping invalid border color RGB(%g, %g, %g) to "
-                       "RGB(%g, %g, %g)\n",
-                       red, green, blue, settings.color.r, settings.color.g,
-                       settings.color.b);
-        }
     } else {
         log_printf(WARNINGS, "warning", "Invalid wrap mode \"%s\"\n", name);
+    }
+
+    // CLAMP_TO_BORDER fills unmapped pixels of the image with BORDER_COLOR
+    // This is where the user can define the color they want to use
+
+    // <wrap mode="clamp_to_border" r="1.0" g="0.0" b="1.0"></wrap>
+    //                            ^^^^^^^^^^^^^^^^^^^^^^^
+
+    element->QueryFloatAttribute("r", &settings.color.r);
+    element->QueryFloatAttribute("g", &settings.color.g);
+    element->QueryFloatAttribute("b", &settings.color.b);
+
+    element->QueryFloatAttribute("red", &settings.color.r);
+    element->QueryFloatAttribute("green", &settings.color.g);
+    element->QueryFloatAttribute("blue", &settings.color.b);
+
+    float red = settings.color.r;
+    float green = settings.color.g;
+    float blue = settings.color.b;
+
+    if (red < 0.0 || red > 1.0 || green < 0.0 || green > 1.0 || blue < 0.0 ||
+        blue > 1.0) {
+        settings.color.r = glm::clamp(settings.color.r, 0.0f, 1.0f);
+        settings.color.g = glm::clamp(settings.color.g, 0.0f, 1.0f);
+        settings.color.b = glm::clamp(settings.color.b, 0.0f, 1.0f);
+
+        log_printf(WARNINGS, "warning",
+                   "Clamping invalid border color RGB(%g, %g, %g) to "
+                   "RGB(%g, %g, %g)\n",
+                   red, green, blue, settings.color.r, settings.color.g,
+                   settings.color.b);
     }
 }
 

--- a/lib/graphics/objects/uniform_set.h
+++ b/lib/graphics/objects/uniform_set.h
@@ -22,6 +22,7 @@
 
 #include "graphics/primitives/shader.h"
 #include "graphics/primitives/texture.h"
+#include "logger/logger.h"
 
 /**
  * @brief A set of material uniforms, distinguished by their uniform names
@@ -45,6 +46,9 @@ struct UniformSet final {
     template <class T>
     void set(const char* name, const T& value);
 
+    template <class TexType>
+    void set(const char* name, const TexType* value);
+
    private:
     enum class UniformType {
         Int,
@@ -59,6 +63,16 @@ struct UniformSet final {
         Texture3D,
     };
 
+    template <class TexType>
+    struct TextureUniform final {
+        TextureUniform(const TexType* source) : texture(source) {}
+        TextureUniform(const TexType* source, unsigned tex_slot)
+            : slot(tex_slot), texture(source) {}
+
+        unsigned slot = 0;
+        const TexType* texture;
+    };
+
     struct UniformValue final {
         explicit UniformValue(int value);
         explicit UniformValue(float value);
@@ -68,17 +82,16 @@ struct UniformSet final {
         explicit UniformValue(const glm::mat2& value);
         explicit UniformValue(const glm::mat3& value);
         explicit UniformValue(const glm::mat4& value);
-        explicit UniformValue(const Texture& value);
-        explicit UniformValue(const Texture3D& value);
+        explicit UniformValue(TextureUniform<Texture> value);
+        explicit UniformValue(TextureUniform<Texture3D> value);
 
-        explicit UniformValue(const Texture* value) : UniformValue(*value) {}
-        explicit UniformValue(const Texture3D* value) : UniformValue(*value) {}
+        explicit UniformValue(const Texture* value)
+            : UniformValue(TextureUniform<Texture>(value)) {}
+        explicit UniformValue(const Texture3D* value)
+            : UniformValue(TextureUniform<Texture3D>(value)) {}
 
         UniformValue(const UniformValue&) = default;
-        UniformValue& operator=(const UniformValue&) = default;
-
-        UniformValue(UniformValue&&) = default;
-        UniformValue& operator=(UniformValue&&) = default;
+        UniformValue& operator=(const UniformValue&);
 
         void upload(const Shader& shader, const char* name) const;
 
@@ -94,13 +107,15 @@ struct UniformSet final {
             glm::mat2 mat2;
             glm::mat3 mat3;
             glm::mat4 mat4;
-            const Texture* texture;
-            const Texture3D* texture_3d;
+            TextureUniform<Texture> texture;
+            TextureUniform<Texture3D> texture_3d;
         } value_;
     };
 
    private:
     std::unordered_map<std::string, UniformSet::UniformValue> data_{};
+
+    unsigned slot_count_ = 0;
 };
 
 template <class T>
@@ -112,5 +127,29 @@ inline void UniformSet::set(const char* name, const T& value) {
         found->second = UniformSet::UniformValue(value);
     } else {
         data_.insert({name, UniformSet::UniformValue(value)});
+    }
+}
+
+static const unsigned TEXTURE_LIMIT = 7;
+
+template <class TexType>
+inline void UniformSet::set(const char* name, const TexType* value) {
+    assert(name);
+
+    auto found = data_.find(name);
+    if (found != data_.end()) {
+        found->second =
+            UniformSet::UniformValue(TextureUniform<TexType>(value));
+    } else {
+        if (slot_count_ >= TEXTURE_LIMIT) {
+            log_printf(WARNINGS, "warning",
+                       "Exceeding texture slot count limit, %u out of %u "
+                       "textures in a single uniform batch\n",
+                       slot_count_ + 1, TEXTURE_LIMIT + 1);
+        }
+
+        data_.insert({name, UniformSet::UniformValue(
+                                TextureUniform<TexType>(value, slot_count_))});
+        ++slot_count_;
     }
 }

--- a/lib/graphics/primitives/framebuffer.cpp
+++ b/lib/graphics/primitives/framebuffer.cpp
@@ -54,7 +54,7 @@ void FrameBuffer::unbind() const {
 
 RenderTarget::RenderTarget(unsigned width, unsigned height)
     : FrameBuffer(),
-      texture_(width, height, 0),
+      texture_(width, height),
       rbo_(width, height, GL_DEPTH24_STENCIL8) {
     bind();
     texture_.attach_to_fb(GL_COLOR_ATTACHMENT0);
@@ -67,7 +67,7 @@ const Texture& RenderTarget::get_texture() const { return texture_; }
 
 DepthMap::DepthMap(unsigned width, unsigned height)
     : FrameBuffer(),
-      texture_(width, height, 0, nullptr, GL_DEPTH24_STENCIL8,
+      texture_(width, height, nullptr, GL_DEPTH24_STENCIL8,
                GL_UNSIGNED_INT_24_8) {
     bind();
     texture_.attach_to_fb(GL_DEPTH_STENCIL_ATTACHMENT);

--- a/lib/graphics/primitives/shader.cpp
+++ b/lib/graphics/primitives/shader.cpp
@@ -146,22 +146,6 @@ void Shader::set_uniform_mat4(const char* uniform,
     poll_gl_errors();
 }
 
-void Shader::set_uniform_tex(const char* uniform,
-                             const Texture& texture) const {
-    poll_gl_errors();
-    GLint uni = glGetUniformLocation(id_, uniform);
-    glUniform1i(uni, (GLint)texture.get_slot());
-    poll_gl_errors();
-}
-
-void Shader::set_uniform_tex3d(const char* uniform,
-                               const Texture3D& texture) const {
-    poll_gl_errors();
-    GLint uni = glGetUniformLocation(id_, uniform);
-    glUniform1i(uni, (GLint)texture.get_slot());
-    poll_gl_errors();
-}
-
 void Shader::set_uniform_tex_id(const char* uniform, GLuint tex_slot) const {
     poll_gl_errors();
     GLint uni = glGetUniformLocation(id_, uniform);

--- a/lib/graphics/primitives/shader.h
+++ b/lib/graphics/primitives/shader.h
@@ -35,8 +35,6 @@ struct Shader {
     void set_uniform_mat2(const char* uniform, const glm::mat2& matrix) const;
     void set_uniform_mat3(const char* uniform, const glm::mat3& matrix) const;
     void set_uniform_mat4(const char* uniform, const glm::mat4& matrix) const;
-    void set_uniform_tex(const char* uniform, const Texture& texture) const;
-    void set_uniform_tex3d(const char* uniform, const Texture3D& texture) const;
     void set_uniform_tex_id(const char* uniform, GLuint tex_slot) const;
 
    private:

--- a/lib/graphics/primitives/texture.h
+++ b/lib/graphics/primitives/texture.h
@@ -17,6 +17,12 @@
 struct TextureSettings {
     int wrap = GL_REPEAT;
     int interp = GL_NEAREST;
+
+    struct {
+        float r = 0.0;
+        float g = 0.0;
+        float b = 0.0;
+    } color;
 };
 
 struct Texture {

--- a/lib/graphics/primitives/texture.h
+++ b/lib/graphics/primitives/texture.h
@@ -14,21 +14,25 @@
 
 #include "graphics/libs.h"
 
+struct TextureSettings {
+    int wrap = GL_REPEAT;
+    int interp = GL_NEAREST;
+};
+
 struct Texture {
-    Texture(const char* path, unsigned slot);
-    Texture(unsigned width, unsigned height, unsigned slot,
+    Texture(const char* path);
+    Texture(unsigned width, unsigned height,
             const unsigned char* data = nullptr, GLint int_format = GL_RGB,
             GLenum format = GL_RGB);
 
     Texture& operator=(const Texture& texture) = delete;
     Texture(const Texture& texture) = delete;
 
-    void set_slot(unsigned slot) { slot_ = slot; }
-    unsigned get_slot() const { return slot_; }
-
-    void bind() const;
+    void bind(unsigned slot) const;
 
     void attach_to_fb(GLenum attachment) const;
+
+    void use_settings(const TextureSettings& settings) const;
 
    protected:
     void load_params(const unsigned char* data = nullptr) const;
@@ -37,23 +41,21 @@ struct Texture {
     GLint int_format_ = GL_RGB;
     GLenum format_ = GL_RGB;
     GLuint id_ = 0;
-    unsigned slot_ = 0;
     unsigned width_ = 0, height_ = 0;
 };
 
 struct Texture3D {
-    Texture3D(unsigned size_x, unsigned size_y, unsigned size_z, unsigned slot,
+    Texture3D(unsigned size_x, unsigned size_y, unsigned size_z,
               GLint int_format = GL_RGB, GLenum format = GL_RGB);
 
     Texture3D& operator=(const Texture3D& texture) = delete;
     Texture3D(const Texture3D& texture) = delete;
 
-    void set_slot(unsigned slot) { slot_ = slot; }
-    unsigned get_slot() const { return slot_; }
-
-    void bind() const;
+    void bind(unsigned slot) const;
 
     void synch(const unsigned char* data = nullptr) const;
+
+    void use_settings(const TextureSettings& settings) const;
 
    protected:
     void load_params(const unsigned char* data = nullptr) const;
@@ -62,7 +64,6 @@ struct Texture3D {
     GLint int_format_ = GL_RGB;
     GLenum format_ = GL_RGB;
     GLuint id_ = 0;
-    unsigned slot_ = 0;
     unsigned size_x_ = 0, size_y_ = 0, size_z_ = 0;
 };
 

--- a/lib/managers/asset_manager.cpp
+++ b/lib/managers/asset_manager.cpp
@@ -47,27 +47,6 @@ void AssetManager::unload_all() {
     assets_.clear();
 }
 
-const char* trim_path(const char* path) {
-    static char trimmed[PATH_LENGTH] = "";
-
-    copy_trimmed(trimmed, path);
-
-    return trimmed;
-}
-
-void copy_trimmed(char destination[PATH_LENGTH], const char* source) {
-    char* out = destination;
-
-    for (const char* chr = source; *chr != '\0'; ++chr) {
-        if (!isgraph(*chr)) continue;
-
-        *out = *chr;
-        ++out;
-    }
-
-    *out = '\0';
-}
-
 AbstractImporter::AbstractImporter(size_t type_id, const char* signature)
     : id_(type_id, signature) {
     AssetManager::register_importer(*this);

--- a/lib/managers/asset_manager.h
+++ b/lib/managers/asset_manager.h
@@ -25,9 +25,6 @@
 
 static const size_t PATH_LENGTH = 1024;
 
-const char* trim_path(const char* path);
-void copy_trimmed(char destination[PATH_LENGTH], const char* source);
-
 struct AbstractAsset {
     virtual ~AbstractAsset() = default;
 


### PR DESCRIPTION
It is now possible to use textures without worrying about their slots. The framework will take care of them by itself and warn you if texture overflow is detected.

The change also comes with new asset descriptor formats for textures, models and shaders.

## Textures

It is now possible to load textures directly from their content files.

```C++
Texture* texture = AssetManager::request<Texture>("path/to/the/texture.png");
```

```XML
<texture uniform="albedo" path="path/to/the/texture.png"></texture>
```

Importers recognize textures in `bmp`, `png` and `jpg` formats.
They still need to have RGB 8bpc pixel format, though.

Texture descriptors did not go to waste. They can be used for wrapping and interpolation modes specification.

```XML
<texture>
    <file path="assets/textures/field_ao.png"></file>
    <interp mode="linear"></interp>
    <wrap mode="clamp_to_border" r="1.0" g="1.0" b="1.0"></wrap>
</texture>
```

By default textures have interpolation mode set to `nearest` and `repeat` wrapping.

Possible interpolation options:

- `nearest` - the value of the texture at given position is considered to be the nearest (in Manhattan distance) to the position,
- `linear` - the value of the texture at given position is considered to be the weighted average of the pixels that are closest to the specified texture coordinates. 

Possible wrapping options:
- `repeat` - repeat the texture by ignoring integer part of the coordinate,
- `mirrored_repeat` - same as repeat, but the texture gets flipped every time it is repeated,
- `clamp_to_edge` - clams position coordinates in a range (0.0, 1.0), therefore extending texture borders,
- `clamp_to_border` - use `BORDER_COLOR` if the dot is outside of the $(0.0, 1.0)^2$ rectangle.

Border color can be specified with `r` (or `red`), `g` (or `green`) and `b` (or `blue`) attributes of the `wrap` tag.

```XML
<wrap mode="clamp_to_border" r="1.0" g="1.0" b="1.0"></wrap>
```

Wrapping mode demonstration from https://learnopengl.com/Getting-started/Textures (original image by Hólger Rezende):

![image](https://github.com/Sigmarik/graphics-engine/assets/55981703/48212d54-d3f5-4573-9502-24e52594967f)
(left to right: `repeat`, `mirrored_repeat`, `clamp_to_edge` and `clamp_to_border`)

## Models

File paths now follow the same pattern as texture paths:

```XML
<model>
    <mesh path="my/model.obj"></mesh>
    <material path="my/material.material.xml"></material>
</model>
```

## Shaders

```XML
<shader>
    <fsh path="my/shader.fsh"></fsh>
    <vsh path="my/shader.vsh"></vsh>
</shader>
```