### PR TITLE
Better update scheduling with `TickManager`

### DIFF
--- a/lib.flist
+++ b/lib.flist
@@ -6,6 +6,7 @@ include/tinyxml2.o
 
 lib/managers/asset_manager.o
 lib/managers/world_timer.o
+lib/managers/tick_manager.o
 
 lib/geometry/primitives.o
 lib/geometry/transforms.o

--- a/lib/graphics/objects/decal.h
+++ b/lib/graphics/objects/decal.h
@@ -12,8 +12,6 @@
 #ifndef DECAL_H
 #define DECAL_H
 
-#include <time.h>
-
 #include "material.h"
 #include "scene.h"
 
@@ -31,7 +29,7 @@ struct Decal : public Renderable {
    private:
     const Material* material_;
     const double time_to_live_;
-    clock_t spawn_time_;
+    uint64_t spawn_time_;
 };
 
 #endif

--- a/lib/managers/tick_manager.cpp
+++ b/lib/managers/tick_manager.cpp
@@ -1,0 +1,84 @@
+#include "tick_manager.h"
+
+#include "logger/logger.h"
+#include "managers/world_timer.h"
+
+//! WARNING: Linux-only implementation of usleep()
+#include <unistd.h>
+
+TickManager::TickManager(const std::function<void()>& input,
+                         const SimpleUpdate& physics,
+                         const ExterpUpdate& graphics)
+    : update_input_(input), update_phys_(physics), update_graph_(graphics) {
+    reset_timers();
+}
+
+void TickManager::reset_timers() {
+    time_ = phys_time_ = WorldTimer::get_time_sec();
+}
+
+void TickManager::tick() {
+    double time = WorldTimer::get_time_sec();
+    delta_time_ = time - time_;
+    time_ = time;
+
+    if (fps_cap_ > 0 && 1.0 / fps_cap_ > delta_time_) {
+        usleep((unsigned)((1.0 / fps_cap_ - delta_time_) * 1e6));
+        delta_time_ = 1.0 / fps_cap_;
+    }
+
+    if (tps_ > 0) {
+        slice_phys_tick();
+    } else {
+        update_input_();
+        update_phys_(delta_time_);
+        phys_time_ = time_;
+    }
+
+    update_graph_(delta_time_, time_ - phys_time_);
+
+    if (fps_threshold_ * delta_time_ > 1.0) {
+        log_printf(WARNINGS, "warning",
+                   "Can not keep up with FPS requirement of %lg. Is the "
+                   "visualization overloaded? (dt: %lg, fps: %lg)\n",
+                   fps_threshold_, delta_time_, 1.0 / delta_time_);
+    }
+
+    ++tick_id_;
+    age_ += delta_time_;
+}
+
+void TickManager::slice_phys_tick() {
+    unsigned subtick_count = 0;
+
+    double phys_dt = 1.0 / tps_;
+
+    while (subtick_count < wormhole_threshold_ &&
+           phys_time_ + phys_dt < time_) {
+        ++subtick_count;
+
+        phys_time_ += phys_dt;
+
+        update_input_();
+        update_phys_(phys_dt);
+    }
+
+    if (subtick_count >= wormhole_threshold_) {
+        log_printf(WARNINGS, "warning",
+                   "Can not keep up with TPS requirement of %u (made %u "
+                   "iterations before aborting). Is the simulation "
+                   "overloaded? (dt: %lg, fps: %lg)\n",
+                   tps_, subtick_count, delta_time_, 1.0 / delta_time_);
+        phys_time_ = time_;
+    }
+}
+
+TickManager* GameLoop::manager_ = nullptr;
+
+void GameLoop::run(TickManager& manager, std::function<bool()> stop_condition) {
+    manager_ = &manager;
+
+    while (!stop_condition()) {
+        manager_->tick();
+    }
+}

--- a/lib/managers/tick_manager.cpp
+++ b/lib/managers/tick_manager.cpp
@@ -74,6 +74,7 @@ void TickManager::slice_phys_tick() {
 }
 
 TickManager* GameLoop::manager_ = nullptr;
+GameLoop GameLoop::instance_;
 
 void GameLoop::run(TickManager& manager, std::function<bool()> stop_condition) {
     manager_ = &manager;

--- a/lib/managers/tick_manager.h
+++ b/lib/managers/tick_manager.h
@@ -1,0 +1,124 @@
+/**
+ * @file tick_manager.h
+ * @author Kudryashov Ilya (kudriashov.it@phystech.edu)
+ * @brief Tick manager class
+ * @version 0.1
+ * @date 2024-03-19
+ *
+ * @copyright Copyright (c) 2024
+ *
+ */
+
+#pragma once
+
+#include <functional>
+#include <optional>
+
+/**
+ * @brief Simulation update scheduler
+ *
+ */
+struct TickManager final {
+    using SimpleUpdate = std::function<void(double)>;
+    using ExterpUpdate = std::function<void(double, double)>;
+
+    TickManager(const std::function<void()>& input, const SimpleUpdate& physics,
+                const ExterpUpdate& graphics);
+
+    void reset_timers();
+    void tick();
+
+    /**
+     * @brief Set TPS requirement
+     *
+     * @param[in] tps required TPS (0 if should be synched with FPS)
+     */
+    void set_tps_req(unsigned tps) { tps_ = tps; }
+    unsigned get_tps_req() const { return tps_; }
+
+    /**
+     * @brief Set framerate cap for the simulation
+     *
+     * @param[in] fps framerate cap
+     */
+    void set_fps_cap(unsigned fps) { fps_cap_ = fps; }
+    unsigned get_fps_cap() const { return fps_cap_; }
+
+    /**
+     * @brief Set how many physics subticks should be performed before tick
+     * manager slows down the simulation to fulfill the TPS requirement
+     *
+     * @param[in] threshold
+     */
+    void set_wormhole_threshold(unsigned threshold) {
+        wormhole_threshold_ = threshold;
+    }
+
+    /**
+     * @brief Set lowest expected FPS
+     *
+     * @param[in] threshold
+     */
+    void set_low_fps_threshold(unsigned threshold) {
+        fps_threshold_ = threshold;
+    }
+
+    double get_real_tps() const { return tps_ > 0 ? tps_ : get_fps(); }
+    double get_fps() const { return 1.0 / delta_time_; }
+
+    unsigned long long get_tick_id() const { return tick_id_; }
+    double get_age() const { return age_; }
+
+   private:
+    void slice_phys_tick();
+
+    std::function<void()> update_input_;
+    SimpleUpdate update_phys_;
+    ExterpUpdate update_graph_;
+
+    double time_ = 0.0;
+    double phys_time_ = 0.0;
+
+    unsigned tps_ = 0;
+    unsigned fps_cap_ = 0;
+
+    double delta_time_ = 0.0;
+
+    unsigned wormhole_threshold_ = 100;
+    double fps_threshold_ = 20.0;
+
+    unsigned long long tick_id_ = 0;
+    double age_ = 0.0;
+};
+
+/**
+ * @brief Main loop of the program
+ *
+ */
+struct GameLoop {
+    /**
+     * @brief Run the simulation with the given tick manager until it is stopped
+     *
+     * @param[in] manager
+     * @param[in] stop_condition
+     */
+    static void run(TickManager& manager, std::function<bool()> stop_condition);
+
+    /**
+     * @brief Get tick manager of the simulation (nullptr if stopped)
+     *
+     * @return TickManager*
+     */
+    static TickManager* get_manager() { return manager_; }
+
+    /**
+     * @brief Stop the simulation after the current tick ends
+     *
+     */
+    static void stop() { manager_ = nullptr; }
+
+    static bool is_running() { return manager_ != nullptr; }
+
+   private:
+    static TickManager* manager_;
+};

--- a/lib/managers/tick_manager.h
+++ b/lib/managers/tick_manager.h
@@ -79,7 +79,7 @@ struct TickManager final {
     double time_ = 0.0;
     double phys_time_ = 0.0;
 
-    unsigned tps_ = 0;
+    unsigned tps_ = 60;
     unsigned fps_cap_ = 0;
 
     double delta_time_ = 0.0;

--- a/lib/managers/tick_manager.h
+++ b/lib/managers/tick_manager.h
@@ -95,7 +95,7 @@ struct TickManager final {
  * @brief Main loop of the program
  *
  */
-struct GameLoop {
+struct GameLoop final {
     /**
      * @brief Run the simulation with the given tick manager until it is stopped
      *
@@ -120,5 +120,8 @@ struct GameLoop {
     static bool is_running() { return manager_ != nullptr; }
 
    private:
+    GameLoop() = default;
+
     static TickManager* manager_;
+    static GameLoop instance_;
 };

--- a/lib/managers/world_timer.cpp
+++ b/lib/managers/world_timer.cpp
@@ -1,12 +1,23 @@
 #include "world_timer.h"
 
-clock_t WorldTimer::SIM_START_ = 0;
+#include "GLFW/glfw3.h"
 
-clock_t WorldTimer::get_time() {
-    clock_t current = clock();
+uint64_t WorldTimer::SIM_START_ = glfwGetTimerValue();
+WorldTimer WorldTimer::instance_;
+
+uint64_t WorldTimer::get_time() {
+    uint64_t current = glfwGetTimerValue();
     return current - SIM_START_;
 }
 
-double WorldTimer::get_time_sec() { return (double)get_time() / 100000.0; }
+double WorldTimer::get_time_sec() {
+    uint64_t time = get_time();
+    uint64_t frequency = glfwGetTimerFrequency();
 
-WorldTimer::WorldTimer() { SIM_START_ = clock(); }
+    uint64_t whole = time / frequency;
+    uint64_t remainder = time % frequency;
+
+    return (double)whole + (double)remainder / (double)frequency;
+}
+
+WorldTimer::WorldTimer() { SIM_START_ = glfwGetTimerValue(); }

--- a/lib/managers/world_timer.h
+++ b/lib/managers/world_timer.h
@@ -9,27 +9,18 @@
  *
  */
 
-#ifndef WORLD_TIMER_H
-#define WORLD_TIMER_H
+#pragma once
 
-#include <time.h>
+#include "inttypes.h"
 
-struct WorldTimer {
-    static clock_t get_time();
+struct WorldTimer final {
+    static uint64_t get_time();
 
     static double get_time_sec();
 
    private:
     WorldTimer();
-    WorldTimer(const WorldTimer& timer) = default;
-    WorldTimer& operator=(const WorldTimer& timer) = default;
 
-    static WorldTimer& get_instance() {
-        static WorldTimer timer;
-        return timer;
-    }
-
-    static clock_t SIM_START_;
+    static uint64_t SIM_START_;
+    static WorldTimer instance_;
 };
-
-#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,6 +80,9 @@ int main(const int argc, char** argv) {
             glfwSwapBuffers(window);
         });
 
+    // Synch physics and graphics ticks, disable TPS requirements
+    ticker.set_tps_req(0);
+
     log_printf(STATUS_REPORTS, "status", "Entering the loop.\n");
     GameLoop::run(ticker, [window]() { return glfwWindowShouldClose(window); });
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,30 +11,13 @@
 
 #include <unistd.h>
 
-#include <glm/ext/matrix_transform.hpp>
-
-#include "components/misc/rc_head.h"
-#include "generation/noise.h"
 #include "graphics/gl_debug.h"
-#include "graphics/objects/ambient_light.h"
-#include "graphics/objects/decal.h"
-#include "graphics/objects/model.h"
-#include "graphics/objects/point_light.h"
-#include "graphics/objects/postprocessor.h"
-#include "graphics/objects/scene.h"
-#include "graphics/primitives/camera.h"
-#include "graphics/primitives/mesh.h"
-#include "graphics/primitives/render_frame.h"
-#include "graphics/primitives/texture.h"
+#include "input/input_controller.h"
 #include "io/main_io.h"
-#include "lib/input/input_controller.h"
 #include "logger/debug.h"
 #include "logger/logger.h"
-#include "logics/components/visual/static_mesh.h"
-#include "logics/scene.h"
 #include "managers/asset_manager.h"
 #include "managers/tick_manager.h"
-#include "managers/world_timer.h"
 #include "scenes/pool_game.h"
 #include "utils/main_utils.h"
 


### PR DESCRIPTION
## Tick manager

`TickManager` is an encapsulation of the scheduling logics required for a game to function.
It takes care of things like physics/graphics synchronization, simulation deadlines and FPS capping.

## Game loop

`GameLoop` is a singleton that
- Encapsulates the `while (. . .) { update(); }` loop,
- Allows components to change the current tick manager's settings.

```C++
TickManager ticker(
    // Input
    []() { /* Dispatch the input event queue */ },

    // Physics
    [](double delta_time) { /* Update physics */ },

    // Graphics
    [](double delta_time, double subtick_time) {
        // Render the scene
    });

// Entering the `while (. . .) { update(); }` loop
GameLoop::run(ticker, []() -> bool { /* When to exit the loop */ });

// Stuff to do after the the main loop has ended

. . .
```

## Warnings

`TickManager` implements two very important performance checks.

If the TPS requirement is set too high and the user's computer fails to meet the deadlines put in front of it, it is possible for the program to loop itself in an endless sequence of deadline misses.
This is why the `TickManager` caps physics tick repetitions to `wormhole_threshold` (100 iterations per draw tick by default). Whenever the iteration limit is exceeded, the tick manager prints out a warning and slows down the simulation to avoid the described "meltdown" scenario.
The issue can be resolved by either optimizing the simulation or, in case the author intends to perform more than 100 physics iterations every draw tick, changing the wormhole threshold through `set_wormhole_threshold` method.

The tick manager also detects frames with FPS below `fps_threshold` (20 frames per second by default). Ticking slower than this results in a warning being added to logs.