### PR TITLE
Advanced window subtitles (alternative implementation)

### DIFF
--- a/lib/managers/window_manager.cpp
+++ b/lib/managers/window_manager.cpp
@@ -6,6 +6,10 @@
 #include "logger/logger.h"
 #include "managers/world_timer.h"
 
+static void handle_glfw_errors(int code, const char* description) {
+    log_printf(ERROR_REPORTS, "GLFW error", "%s\n", description);
+}
+
 GLFWwindow* WindowManager::window_ = nullptr;
 std::vector<std::weak_ptr<WindowManager::SubtitleDataBlock>>
     WindowManager::subtitle_info_{};
@@ -17,11 +21,12 @@ bool WindowManager::requires_title_update_ = false;
 void WindowManager::init(size_t width, size_t height, const char* title,
                          bool fullscreen) {
     glfwInit();
+
+    glfwSetErrorCallback(handle_glfw_errors);
+
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
     glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
     glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
-
-    glfwWindowHint(GLFW_SAMPLES, 4);
 
     GLFWwindow* window =
         glfwCreateWindow(int(width), int(height), title,

--- a/lib/managers/window_manager.cpp
+++ b/lib/managers/window_manager.cpp
@@ -50,7 +50,10 @@ void WindowManager::init(size_t width, size_t height, const char* title,
     set_title(title, true);
 }
 
-void WindowManager::terminate() { glfwTerminate(); }
+void WindowManager::terminate() {
+    glfwTerminate();
+    window_ = nullptr;
+}
 
 GLFWwindow* WindowManager::get_active_window() { return window_; }
 
@@ -63,6 +66,9 @@ void WindowManager::set_title(const char* title, bool halt_update) {
 }
 
 void WindowManager::update_title() {
+    if (!valid()) return;
+    if (!requires_title_update_) return;
+
     last_title_update_ = WorldTimer::get_time_sec();
     requires_title_update_ = false;
 
@@ -90,6 +96,8 @@ void WindowManager::update_title() {
 }
 
 void WindowManager::refresh() {
+    if (!valid()) return;
+
     double time = WorldTimer::get_time_sec();
 
     if (last_title_update_ + subtitle_update_dt_ < time) {

--- a/lib/managers/window_manager.cpp
+++ b/lib/managers/window_manager.cpp
@@ -12,7 +12,7 @@ std::vector<std::weak_ptr<WindowManager::SubtitleDataBlock>>
 std::string WindowManager::window_title_ = "[UNDEFINED TITLE]";
 double WindowManager::last_title_update_ = 0.0;
 double WindowManager::subtitle_update_dt_ = 0.0;
-bool WindowManager::requires_title_update_ = 0.0;
+bool WindowManager::requires_title_update_ = false;
 
 void WindowManager::init(size_t width, size_t height, const char* title,
                          bool fullscreen) {
@@ -101,11 +101,12 @@ void WindowManager::refresh() {
 
 WindowManager::SubtitleEntry WindowManager::add_subtitle_entry(
     const std::string& key, double frequency) {
-    SubtitleEntry entry(key, 1.0 / frequency);
+    double delta_time = frequency == 0.0 ? 0.0 : 1.0 / frequency;
+    SubtitleEntry entry(key, delta_time);
 
     subtitle_info_.push_back(entry.get_data());
 
-    notify_subtitle_stat_change();
+    subtitle_update_dt_ = std::min(subtitle_update_dt_, delta_time);
 
     return entry;
 }

--- a/lib/managers/window_manager.cpp
+++ b/lib/managers/window_manager.cpp
@@ -4,10 +4,15 @@
 
 #include "graphics/gl_debug.h"
 #include "logger/logger.h"
+#include "managers/world_timer.h"
 
 GLFWwindow* WindowManager::window_ = nullptr;
-std::unordered_map<std::string, std::string> WindowManager::subtitle_info_ = {};
+std::vector<std::weak_ptr<WindowManager::SubtitleDataBlock>>
+    WindowManager::subtitle_info_{};
 std::string WindowManager::window_title_ = "[UNDEFINED TITLE]";
+double WindowManager::last_title_update_ = 0.0;
+double WindowManager::subtitle_update_dt_ = 0.0;
+bool WindowManager::requires_title_update_ = 0.0;
 
 void WindowManager::init(size_t width, size_t height, const char* title,
                          bool fullscreen) {
@@ -49,34 +54,18 @@ void WindowManager::terminate() { glfwTerminate(); }
 
 GLFWwindow* WindowManager::get_active_window() { return window_; }
 
-void WindowManager::set_subtitle_entry(const std::string& key,
-                                       const std::string& value,
-                                       bool halt_update) {
-    subtitle_info_[key] = value;
-
-    if (!halt_update) update_title();
-}
-
-void WindowManager::clear_subtitle(bool halt_update) {
-    subtitle_info_.clear();
-
-    if (!halt_update) update_title();
-}
-
-void WindowManager::remove_subtitle_entry(const std::string& key,
-                                          bool halt_update) {
-    subtitle_info_.erase(key);
-
-    if (!halt_update) update_title();
-}
-
 void WindowManager::set_title(const char* title, bool halt_update) {
     window_title_ = title;
+
+    request_title_update();
 
     if (!halt_update) update_title();
 }
 
 void WindowManager::update_title() {
+    last_title_update_ = WorldTimer::get_time_sec();
+    requires_title_update_ = false;
+
     std::stringstream stream;
 
     stream << window_title_;
@@ -85,8 +74,9 @@ void WindowManager::update_title() {
         stream << " (";
 
         size_t index = 0;
-        for (const auto& [key, value] : subtitle_info_) {
-            stream << key << ": " << value;
+        for (const auto& entry : subtitle_info_) {
+            SubtitleDataBlock& data = *entry.lock();
+            stream << data.key << ": " << data.value;
 
             if (index + 1 != subtitle_info_.size()) stream << ", ";
 
@@ -97,4 +87,62 @@ void WindowManager::update_title() {
     }
 
     glfwSetWindowTitle(window_, stream.str().c_str());
+}
+
+void WindowManager::refresh() {
+    double time = WorldTimer::get_time_sec();
+
+    if (last_title_update_ + subtitle_update_dt_ < time) {
+        update_title();
+    }
+
+    glfwSwapBuffers(get_active_window());
+}
+
+WindowManager::SubtitleEntry WindowManager::add_subtitle_entry(
+    const std::string& key, double frequency) {
+    SubtitleEntry entry(key, 1.0 / frequency);
+
+    subtitle_info_.push_back(entry.get_data());
+
+    notify_subtitle_stat_change();
+
+    return entry;
+}
+
+void WindowManager::notify_subtitle_stat_change() {
+    if (subtitle_info_.empty()) return;
+
+    size_t left_id = 0;
+
+    for (size_t right_id = 0; right_id < subtitle_info_.size(); ++right_id) {
+        if (!subtitle_info_[right_id].expired()) {
+            subtitle_info_[left_id] = subtitle_info_[right_id];
+            ++left_id;
+        }
+    }
+
+    subtitle_info_.resize(left_id);
+
+    if (subtitle_info_.empty()) return;
+
+    subtitle_update_dt_ = subtitle_info_[0].lock()->refresh_dt;
+
+    for (const auto& entry : subtitle_info_) {
+        subtitle_update_dt_ =
+            std::min(entry.lock()->refresh_dt, subtitle_update_dt_);
+    }
+}
+
+WindowManager::SubtitleEntry::~SubtitleEntry() {
+    data_.reset();
+
+    WindowManager::notify_subtitle_stat_change();
+}
+
+WindowManager::SubtitleEntry::SubtitleEntry(const std::string& key,
+                                            double refresh_dt)
+    : data_(std::make_shared<WindowManager::SubtitleDataBlock>()) {
+    data_->key = key;
+    data_->refresh_dt = refresh_dt;
 }

--- a/lib/managers/window_manager.cpp
+++ b/lib/managers/window_manager.cpp
@@ -134,11 +134,14 @@ void WindowManager::notify_subtitle_stat_change() {
     }
 }
 
-WindowManager::SubtitleEntry::~SubtitleEntry() {
-    data_.reset();
+void WindowManager::SubtitleEntry::hide() {
+    if (!*this) return;
 
+    data_.reset();
     WindowManager::notify_subtitle_stat_change();
 }
+
+WindowManager::SubtitleEntry::~SubtitleEntry() { hide(); }
 
 WindowManager::SubtitleEntry::SubtitleEntry(const std::string& key,
                                             double refresh_dt)

--- a/lib/managers/window_manager.h
+++ b/lib/managers/window_manager.h
@@ -79,13 +79,12 @@ struct WindowManager {
      * value, key: value)`.
      *
      * @param[in] key entry key
-     * @param[in] frequency subtitle update frequency requirement (zero causes
-     * the title to update as frequently as possible) (10 times per second by
-     * default)
+     * @param[in] expiration_time time requirement between title updates for a
+     * parameter (0.1 by default)
      * @return SubtitleEntry
      */
     static SubtitleEntry add_subtitle_entry(const std::string& key,
-                                            double frequency = 10.0);
+                                            double expiration_time = 0.1);
 
    private:
     static void notify_subtitle_stat_change();

--- a/lib/managers/window_manager.h
+++ b/lib/managers/window_manager.h
@@ -7,13 +7,40 @@
 #include "graphics/libs.h"
 
 struct WindowManager {
+    /**
+     * @brief Construct the main program window and initialize graphics
+     * libraries.
+     *
+     * @param[in] width window width
+     * @param[in] height window height
+     * @param[in] title window title ("Unnamed" by default)
+     * @param[in] fullscreen weather the window should be in full screen mode
+     *
+     * @note In case of an error the window pointer remains `nullptr`, which can
+     * be checked using `WindowManager::valid()` call.
+     */
     static void init(size_t width, size_t height, const char* title = "Unnamed",
                      bool fullscreen = false);
 
+    /**
+     * @brief Destroy the main window
+     *
+     */
     static void terminate();
 
+    /**
+     * @brief Get the currently active window
+     *
+     * @return GLFWwindow*
+     */
     static GLFWwindow* get_active_window();
 
+    /**
+     * @brief Check weather the window has been initialized
+     *
+     * @return true
+     * @return false
+     */
     static bool valid() { return window_ != nullptr; }
 
     struct SubtitleEntry;
@@ -25,12 +52,20 @@ struct WindowManager {
      * @warning Should be preferred over `glfwSetWindowTitle`, as this function
      * respects window subtitles
      *
-     * @param[in] halt_update
+     * @param[in] halt_update weather the title update should be halted
      */
     static void set_title(const char* title, bool halt_update = false);
 
+    /**
+     * @brief Force-update the title
+     *
+     */
     static void update_title();
 
+    /**
+     * @brief Swap display buffers and update window title if needed.
+     *
+     */
     static void refresh();
 
     struct SubtitleDataBlock {
@@ -39,6 +74,16 @@ struct WindowManager {
         double refresh_dt = 0.1;
     };
 
+    /**
+     * @brief Add an entry to the window subtitle `window_title (subtitle_key:
+     * value, key: value)`.
+     *
+     * @param[in] key entry key
+     * @param[in] frequency subtitle update frequency requirement (zero causes
+     * the title to update as frequently as possible) (10 times per second by
+     * default)
+     * @return SubtitleEntry
+     */
     static SubtitleEntry add_subtitle_entry(const std::string& key,
                                             double frequency = 10.0);
 
@@ -58,11 +103,29 @@ struct WindowManager {
 };
 
 struct WindowManager::SubtitleEntry {
+    /**
+     * @brief Set displayed value of the entry
+     *
+     * @param[in] value
+     *
+     * @note Call after `hide` will have no effect on the title.
+     */
     void set_value(const std::string& value) {
+        if (!*this) return;
+
         data_->value = value;
         WindowManager::request_title_update();
     }
 
+    /**
+     * @brief Set displayed value of the entry
+     *
+     * @tparam T argument type (should be convertible to string using
+     * std::to_string)
+     * @param[in] value
+     *
+     * @note Call after `hide` will have no effect on the title.
+     */
     template <class T>
     requires requires(T&& t) { std::to_string(t); }
     void set_value(T&& value) {
@@ -74,6 +137,12 @@ struct WindowManager::SubtitleEntry {
 
     friend WindowManager;
 
+    /**
+     * @brief Remove entry from the window subtitle.
+     *
+     * @note Can be called however many times over.
+     * @note Does not affect correctness of `set_value` calls.
+     */
     void hide();
 
     operator bool() const { return static_cast<bool>(data_); }

--- a/lib/managers/window_manager.h
+++ b/lib/managers/window_manager.h
@@ -66,11 +66,17 @@ struct WindowManager::SubtitleEntry {
     template <class T>
     requires requires(T&& t) { std::to_string(t); }
     void set_value(T&& value) {
+        if (!*this) return;
+
         data_->value = std::to_string(value);
         WindowManager::request_title_update();
     }
 
     friend WindowManager;
+
+    void hide();
+
+    operator bool() const { return static_cast<bool>(data_); }
 
     ~SubtitleEntry();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,6 +62,9 @@ int main(const int argc, char** argv) {
 
     poll_gl_errors();
 
+    auto fps_display = WindowManager::add_subtitle_entry("FPS");
+    auto tps_display = WindowManager::add_subtitle_entry("TPS");
+
     TickManager ticker(
         // Input
         []() { InputController::poll_events(); },
@@ -70,7 +73,8 @@ int main(const int argc, char** argv) {
         [](double delta_time) { world.phys_tick(delta_time); },
 
         // Graphics
-        [&gbuffers, &ticker](double delta_time, double subtick_time) {
+        [&gbuffers, &ticker, &fps_display, &tps_display](double delta_time,
+                                                         double subtick_time) {
             world.draw_tick(delta_time, subtick_time);
 
             glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
@@ -78,12 +82,10 @@ int main(const int argc, char** argv) {
 
             poll_gl_errors();
 
-            glfwSwapBuffers(WindowManager::get_active_window());
+            WindowManager::refresh();
 
-            WindowManager::set_subtitle_entry(
-                "FPS", std::to_string(int(ticker.get_fps())), true);
-            WindowManager::set_subtitle_entry(
-                "TPS", std::to_string(int(ticker.get_real_tps())));
+            fps_display.set_value(int(ticker.get_fps()));
+            tps_display.set_value(int(ticker.get_real_tps()));
         });
 
     // Synch physics and graphics ticks, disable TPS requirements

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -73,8 +73,7 @@ int main(const int argc, char** argv) {
         [](double delta_time) { world.phys_tick(delta_time); },
 
         // Graphics
-        [&gbuffers, &ticker, &fps_display, &tps_display](double delta_time,
-                                                         double subtick_time) {
+        [&](double delta_time, double subtick_time) {
             world.draw_tick(delta_time, subtick_time);
 
             glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);


### PR DESCRIPTION
Alternative implementation of the "advanced subtitles" feature.

It utilizes object lifetime for updating the list of properties, which allows it to preserve the order of subtitle entries, have individual update frequency requirements and not rely on string keys for entry recognition.

Usage example:

```C++
auto fps_display = WindowManager::add_subtitle_entry("FPS");

loop {
  fps_display.set_value(int(fps));
}

// Remove the "FPS" tag from the subtitle.
fps_display.hide();

// fps_display destructor will also handle tag removal.
```